### PR TITLE
Move latestId into editor

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -16,6 +16,7 @@ export class NodeEditor extends Context<EventsTypes> {
     nodes: Node[] = [];
     selected = new Selected();
     view: EditorView;
+    latestId: number = 0;
 
     constructor(id: string, container: HTMLElement) {
         super(id, new EditorEvents());
@@ -38,8 +39,25 @@ export class NodeEditor extends Context<EventsTypes> {
         }));
     }
 
+    incrementId() {
+        if (!this.latestId)
+            this.latestId = 1;
+        else
+            this.latestId++;
+        return this.latestId;
+    }
+
+    resetId() {
+        this.latestId = 0;
+    }
+    
     addNode(node: Node) {
         if (!this.trigger('nodecreate', node)) return;
+
+        if (!node.id)
+            node.id = this.incrementId();
+        else
+            this.latestId = Math.max(node.id, this.latestId);
 
         this.nodes.push(node);
         this.view.addNode(node);

--- a/src/node.ts
+++ b/src/node.ts
@@ -7,7 +7,7 @@ import { InputsData, NodeData, OutputsData } from './core/data';
 export class Node {
 
     name: string;
-    id: number;
+    id: number = 0;
     position: [number, number] = [0.0, 0.0];
     inputs = new Map<string, Input>();
     outputs = new Map<string, Output>();
@@ -15,11 +15,8 @@ export class Node {
     data: {[key: string]: unknown} = {};
     meta: {[key: string]: unknown} = {};
 
-    static latestId = 0;
-    
     constructor(name: string) {
         this.name = name;
-        this.id = Node.incrementId();
     }
 
     _add<T extends any>(list: Map<string, T>, item: T, prop: string) {
@@ -78,18 +75,6 @@ export class Node {
 
     update() {}
 
-    static incrementId() {
-        if (!this.latestId)
-            this.latestId = 1
-        else
-            this.latestId++
-        return this.latestId
-    }
-
-    static resetId() {
-        this.latestId = 0;
-    }
-
     toJSON(): NodeData {
         const reduceIO = <T extends any>(list: Map<string, Input | Output>) => {
             return Array.from(list).reduce<T>((obj, [key, io]) => {
@@ -116,7 +101,6 @@ export class Node {
         node.data = json.data;
         node.position = [x, y];
         node.name = json.name;
-        Node.latestId = Math.max(node.id, Node.latestId);
 
         return node;
     }


### PR DESCRIPTION
Moved node id assignment into editor class to preserve numbering across multiple editors.