### PR TITLE
Prevent context-menu click from initiating node drag

### DIFF
--- a/src/view/drag.ts
+++ b/src/view/drag.ts
@@ -25,6 +25,7 @@ export class Drag {
     }
 
     down(e: PointerEvent) {
+        if ((e.pointerType === 'mouse') && (e.button !== 0)) return;
         e.stopPropagation();
         this.pointerStart = [e.pageX, e.pageY]
 


### PR DESCRIPTION
When not using the `context-menu-plugin`, clicking the right mouse button brings up the browser context menu (as expected) but also initiates a node drag which can result in the node being "stuck" to the mouse until the mouse button is clicked again. When using the `context-menu-plugin`, right-click-dragging with the mouse down allows the node to be dragged in addition to the rete context menu being presented. Similarly, on my mouse (on a Mac) the center scroll-wheel button can also be used to drag a node while simultaneously invoking the default center scroll-wheel behavior. The proposed fix here is to limit node drags to the primary mouse button when the input device is a mouse. I looked into the possibility of adding tests as suggested by the guidelines but there don't seem to be any tests for the drag/click behaviors so I wasn't sure how best to go about it.