### PR TITLE
Only zoom when `wheel` event target is program editor

### DIFF
--- a/src/view/zoom.ts
+++ b/src/view/zoom.ts
@@ -33,6 +33,8 @@ export class Zoom {
     }
 
     wheel(e: WheelEvent) {
+        if (e.currentTarget !== e.target) return;
+
         e.preventDefault();
         
         const rect = this.el.getBoundingClientRect();


### PR DESCRIPTION
In our application some of our nodes contain popup menus (HTML &lt;select&gt; elements), but the scroll wheel would not allow scrolling of the popup menu contents. This turned out to be because the Rete Zoom class swallows all `wheel` events by calling `preventDefault()`, thus preventing the subsequent `scroll` event from being generated.

To address this, the approach taken here is to only treat the `wheel` event as a zoom event if it occurs over the editor background, i.e. not over a node. This is accomplished by adding the following line at the top of the `Zoom` class `wheel` event:

```typescript
        if (e.currentTarget !== e.target) return;
```

While this results in an observable change in behavior -- zooming with the scroll wheel can only be accomplished over the white-space of the editor -- it seems justifiable to me in that Rete should allow nodes to make use of the `wheel`/`scroll` events as they see fit. There may be other ways of accomplishing the same goal but this was the simplest I could come up with.