### PR TITLE
Fix 'nodedraged' typo

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -67,7 +67,7 @@ export interface EventsTypes extends DefaultEventsTypes {
     nodetranslate: { node: Node; x: number; y: number };
     nodetranslated: { node: Node; prev: [number, number] };
     nodedraged: Node;
-    nodedraged: Node;
+    nodedragged: Node;
     selectnode: {
         node: Node;
         accumulate: boolean;

--- a/src/events.ts
+++ b/src/events.ts
@@ -26,6 +26,7 @@ export class EditorEvents extends Events {
             nodetranslate: [],
             nodetranslated: [],
             nodedraged: [],
+            nodedragged: [],
             selectnode: [],
             multiselectnode: [],
             nodeselect: [],
@@ -65,6 +66,7 @@ export interface EventsTypes extends DefaultEventsTypes {
     translatenode: { node: Node; dx: number; dy: number };
     nodetranslate: { node: Node; x: number; y: number };
     nodetranslated: { node: Node; prev: [number, number] };
+    nodedraged: Node;
     nodedraged: Node;
     selectnode: {
         node: Node;

--- a/src/view/node.ts
+++ b/src/view/node.ts
@@ -31,6 +31,7 @@ export class NodeView extends Emitter<EventsTypes> {
 
         this._drag = new Drag(this.el, this.onTranslate.bind(this), this.onSelect.bind(this), () => {
             this.trigger('nodedraged', node);
+            this.trigger('nodedragged', node);
         });
 
         this.trigger('rendernode', {


### PR DESCRIPTION
Currently there is a typo in the 'nodedraged' event which should preferrably be spelled 'nodedragged'.

The solution is to create an identical trigger called 'nodedragged' alongside the existing one and to trigger it alongside the old one in the code.