### PR TITLE
Update deprecated asserts

### DIFF
--- a/test/control.ts
+++ b/test/control.ts
@@ -40,9 +40,9 @@ describe('Control', () => {
         assert.doesNotThrow(() => ctrl.getNode(), 'node should be added')
 
         node.data.testKey = 1;
-        assert.equal(ctrl.getData('testKey'), 1, 'data testKey exist')
+        assert.strictEqual(ctrl.getData('testKey'), 1, 'data testKey exist')
 
         assert.doesNotThrow(() => ctrl.putData('testKey2', 2), 'data added')
-        assert.equal(ctrl.getData('testKey2'), 2, 'data testKey2 exist')
+        assert.strictEqual(ctrl.getData('testKey2'), 2, 'data testKey2 exist')
     })
 })

--- a/test/core.ts
+++ b/test/core.ts
@@ -61,10 +61,10 @@ describe('Core', () => {
         const window: any = {};
 
         editor.use(mockPlugin, { window })
-        assert.equal(window._globalVar, 1, 'global property assigned')
+        assert.strictEqual(window._globalVar, 1, 'global property assigned')
 
         editor.destroy();
-        assert.equal(typeof window._globalVar, 'undefined', 'global property deleted')
+        assert.strictEqual(typeof window._globalVar, 'undefined', 'global property deleted')
 
     });
 });

--- a/test/editor.ts
+++ b/test/editor.ts
@@ -48,7 +48,7 @@ describe('Editor', () => {
         it('import', async () => {
             let ret = await editor.fromJSON({ id: 'test@0.0.2', nodes: {} });
     
-            assert.equal(ret, false, 'can not be taken with another id');
+            assert.strictEqual(ret, false, 'can not be taken with another id');
         });
 
         it('export', async () => {
@@ -57,7 +57,7 @@ describe('Editor', () => {
 
             let ret = await editor.fromJSON(addNumbersData as any);
 
-            assert.equal(ret, true, 'correct data');
+            assert.strictEqual(ret, true, 'correct data');
 
             assert.deepEqual(editor.toJSON(), addNumbersData)
         });
@@ -74,39 +74,39 @@ describe('Editor', () => {
             // assert.throws(() => editor.connect(n1.outputs.get('none'), n2.inputs.get('name')), Error, 'no output');
             
             editor.connect(node1.outputs.get('num') as Output, node2.inputs.get('num1') as Input);
-            assert.equal((node1.outputs.get('num') as Output).connections.length, 1, 'one connection');
+            assert.strictEqual((node1.outputs.get('num') as Output).connections.length, 1, 'one connection');
             
             var connection = (node1.outputs.get('num') as Output).connections[0];
 
             assert.doesNotThrow(() => editor.removeConnection(connection), Error, 'remove connection');
-            assert.equal((node1.outputs.get('num') as Output).connections.length, 0, 'no connections');
+            assert.strictEqual((node1.outputs.get('num') as Output).connections.length, 0, 'no connections');
         });
 
         it('nodes', async () => {
             const node1 = await comps[0].createNode();
             const node2 = await comps[0].createNode();
 
-            assert.equal(editor.nodes.length, 0, 'No nodes')
+            assert.strictEqual(editor.nodes.length, 0, 'No nodes')
             editor.addNode(node1)
-            assert.equal(editor.nodes.length, 1, 'One node exist')
+            assert.strictEqual(editor.nodes.length, 1, 'One node exist')
 
             editor.selectNode(node1)
-            assert.equal(editor.selected.contains(node1), true, 'Node selected')
+            assert.strictEqual(editor.selected.contains(node1), true, 'Node selected')
 
             assert.throws(() => editor.selectNode(node2), 'Unable to select not added node')
 
             editor.addNode(node2)
             editor.selectNode(node2, false)
-            assert.equal(editor.selected.contains(node1), false, 'Previous node unselected')
-            assert.equal(editor.selected.contains(node2), true, 'New node selected')
+            assert.strictEqual(editor.selected.contains(node1), false, 'Previous node unselected')
+            assert.strictEqual(editor.selected.contains(node2), true, 'New node selected')
 
             editor.selectNode(node1, true)
-            assert.equal(editor.selected.list.length, 2, 'Both nodes selected')
+            assert.strictEqual(editor.selected.list.length, 2, 'Both nodes selected')
 
             editor.removeNode(node1)
-            assert.equal(editor.nodes.length, 1, 'First node removed')
+            assert.strictEqual(editor.nodes.length, 1, 'First node removed')
             editor.removeNode(node2)
-            assert.equal(editor.nodes.length, 0, 'Second node removed')
+            assert.strictEqual(editor.nodes.length, 0, 'Second node removed')
         })
 
         describe('prevent', () => {
@@ -121,20 +121,20 @@ describe('Editor', () => {
             it('adding node', () => {
                 editor.on('nodecreate', () => false);
                 editor.addNode(node);
-                assert.equal(editor.nodes.length, 0)
+                assert.strictEqual(editor.nodes.length, 0)
             });
 
             it('removing node', () => {
                 editor.on('noderemove', () => false);
                 editor.addNode(node);
                 editor.removeNode(node);
-                assert.equal(editor.nodes.length, 1)
+                assert.strictEqual(editor.nodes.length, 1)
             });
 
             it('connection', () => {
                 editor.on('connectioncreate', () => false);
                 editor.connect(node.outputs.get('num') as Output, node2.inputs.get('num1') as Input)
-                assert.equal((node.outputs.get('num') as Output).hasConnection(), false)
+                assert.strictEqual((node.outputs.get('num') as Output).hasConnection(), false)
             });
 
             it('connection', () => {
@@ -143,11 +143,11 @@ describe('Editor', () => {
                 editor.on('connectionremove', () => false);
                 editor.connect(output, node2.inputs.get('num1') as Input)
 
-                assert.equal(output.hasConnection(), true)
+                assert.strictEqual(output.hasConnection(), true)
 
                 editor.removeConnection(output.connections[0]);
 
-                assert.equal(output.hasConnection(), true)
+                assert.strictEqual(output.hasConnection(), true)
             });
         });
     });

--- a/test/editor.ts
+++ b/test/editor.ts
@@ -59,7 +59,7 @@ describe('Editor', () => {
 
             assert.strictEqual(ret, true, 'correct data');
 
-            assert.deepEqual(editor.toJSON(), addNumbersData)
+            assert.deepStrictEqual(editor.toJSON(), addNumbersData)
         });
 
         it('connections', async () => {

--- a/test/engine.ts
+++ b/test/engine.ts
@@ -37,11 +37,11 @@ describe('Engine', () => {
 
         it('data', async () => {
             assert.strictEqual(await engine.process(data), 'success')
-            assert.notEqual(await engine.process({ id: 'test@1.0.0', nodes: {} }), 'success', 'wrong id')
+            assert.notStrictEqual(await engine.process({ id: 'test@1.0.0', nodes: {} }), 'success', 'wrong id')
         });
     
         it('validation', async () => {
-            assert.notEqual(await engine.process(recursiveData as any), 'success', 'recursive data')
+            assert.notStrictEqual(await engine.process(recursiveData as any), 'success', 'recursive data')
         });  
 
         it('clone', () => {
@@ -49,7 +49,7 @@ describe('Engine', () => {
 
             assert.strictEqual(engineClone instanceof Engine, true, 'is instance')
             assert.strictEqual(engineClone.id, engine.id, 'id')
-            assert.deepEqual(engineClone.components, engine.components, 'components')
+            assert.deepStrictEqual(engineClone.components, engine.components, 'components')
         })
 
         it('abort', (done) => {

--- a/test/engine.ts
+++ b/test/engine.ts
@@ -36,7 +36,7 @@ describe('Engine', () => {
         })
 
         it('data', async () => {
-            assert.equal(await engine.process(data), 'success')
+            assert.strictEqual(await engine.process(data), 'success')
             assert.notEqual(await engine.process({ id: 'test@1.0.0', nodes: {} }), 'success', 'wrong id')
         });
     
@@ -47,19 +47,19 @@ describe('Engine', () => {
         it('clone', () => {
             const engineClone = engine.clone();
 
-            assert.equal(engineClone instanceof Engine, true, 'is instance')
-            assert.equal(engineClone.id, engine.id, 'id')
+            assert.strictEqual(engineClone instanceof Engine, true, 'is instance')
+            assert.strictEqual(engineClone.id, engine.id, 'id')
             assert.deepEqual(engineClone.components, engine.components, 'components')
         })
 
         it('abort', (done) => {
             engine.process(data as any).then(v => {
-                assert.equal(v, 'aborted', 'Check aborted process')
+                assert.strictEqual(v, 'aborted', 'Check aborted process')
             }).catch(done)
             engine.abort();
             
             engine.process(data as any).then(v => {
-                assert.equal(Boolean(v), false, 'Not aborted completely')
+                assert.strictEqual(Boolean(v), false, 'Not aborted completely')
             }).then(done)
         })
 
@@ -71,7 +71,7 @@ describe('Engine', () => {
             it('process warn', (done) => {
                 engine.process(data)
                 engine.process(data).then(r => {
-                    assert.equal(Boolean(r), false, 'cannot process simultaneously')
+                    assert.strictEqual(Boolean(r), false, 'cannot process simultaneously')
                 }).then(done).catch(done)
             })
         });
@@ -80,8 +80,8 @@ describe('Engine', () => {
             const correctId = Object.keys(addNumbersData.nodes)[0];
             const wrongId = Number.POSITIVE_INFINITY;
 
-            assert.equal(await engine.process(addNumbersData as any, correctId), 'success')
-            // assert.equal(await engine.process(addNumbersData as any, wrongId), 'error')
+            assert.strictEqual(await engine.process(addNumbersData as any, correctId), 'success')
+            // assert.strictEqual(await engine.process(addNumbersData as any, wrongId), 'error')
         });
     });
 });


### PR DESCRIPTION
As mentioned in #463 
1. replace `assert.equal` with `assert.strictEqual`
2. replace `assert.deepEqual` with `assert.deepStrictEqual` and `assert.notEqual` with `assert.notStrictEqual`