### PR TITLE
Prevent unintended zoom

### DIFF
--- a/src/view/zoom.ts
+++ b/src/view/zoom.ts
@@ -88,6 +88,8 @@ export class Zoom {
     }
 
     dblclick(e: MouseEvent) {
+        if(e.target !== e.currentTarget) return
+
         e.preventDefault();
         
         const rect = this.el.getBoundingClientRect();


### PR DESCRIPTION
Hi there,

The suggested change will prevent zoom-in when interacting with Node components (editing controls etc). 

The zoom-in will take effect If the double-click occurred on the container element only which helps to stabilize the user interface.

Also, really nice work on the project overall.