### PR TITLE
Add `setMeta()` method to Node

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -67,6 +67,11 @@ export class Node {
         this.outputs.delete(output.key);
     }
 
+    setMeta (meta: {[key: string]: unknown}) {
+        this.meta = meta;
+        return this;
+    }
+
     getConnections() {
         const ios = [...this.inputs.values(), ...this.outputs.values()];
         const connections = ios.reduce((arr, io) => {


### PR DESCRIPTION
The PR implements a `setMeta()` method for Nodes to chain it in the component builder:

```js
class MyComponent extends Rete.Component {
    constructor () {
        super('Component name');
    }

    builder (node) {
        return node
            .setMeta({ foo: 'bar' })
            .addControl(...)
            .addInput(...)
            .addOutput(...);
    }
}
```