### PR TITLE
fix: when SocketView.getPosition el.offsetParent is not nodeview.el

### DIFF
--- a/src/view/node.ts
+++ b/src/view/node.ts
@@ -55,7 +55,7 @@ export class NodeView extends Emitter<EventsTypes> {
 
     bindSocket(el: HTMLElement, type: string, io: IO) {
         this.clearSockets();
-        this.sockets.set(io, new SocketView(el, type, io, this.node, this));
+        this.sockets.set(io, new SocketView(el, type, io, this.node, this, this.el));
     }
 
     bindControl(el: HTMLElement, control: Control) {

--- a/src/view/node.ts
+++ b/src/view/node.ts
@@ -55,7 +55,7 @@ export class NodeView extends Emitter<EventsTypes> {
 
     bindSocket(el: HTMLElement, type: string, io: IO) {
         this.clearSockets();
-        this.sockets.set(io, new SocketView(el, type, io, this.node, this, this.el));
+        this.sockets.set(io, new SocketView(el, type, io, this.node, this));
     }
 
     bindControl(el: HTMLElement, control: Control) {
@@ -71,7 +71,7 @@ export class NodeView extends Emitter<EventsTypes> {
 
         if (!socket) throw new Error(`Socket not found for ${io.name} with key ${io.key}`);
 
-        return socket.getPosition(this.node);
+        return socket.getPosition(this.node, this.el);
     }
 
     onSelect(e: MouseEvent) {

--- a/src/view/socket.ts
+++ b/src/view/socket.ts
@@ -2,6 +2,7 @@ import { Emitter } from '../core/emitter';
 import { EventsTypes } from '../events';
 import { IO } from '../io';
 import { Node } from '../node';
+import { NodeView } from './node';
 
 export class SocketView extends Emitter<EventsTypes> {
 
@@ -9,13 +10,15 @@ export class SocketView extends Emitter<EventsTypes> {
     type: string;
     io: IO;
     node: Node;
+    nodeView: NodeView;
 
-    constructor(el: HTMLElement, type: string, io: IO, node: Node, emitter: Emitter<EventsTypes>) {
+    constructor(el: HTMLElement, type: string, io: IO, node: Node, emitter: NodeView) {
         super(emitter);
         this.el = el;
         this.type = type;
         this.io = io;
         this.node = node;
+        this.nodeView = emitter
 
         this.trigger('rendersocket', { el, [type]: this.io, socket: io.socket });
     }
@@ -23,9 +26,17 @@ export class SocketView extends Emitter<EventsTypes> {
     getPosition({ position }: { position: number[] }): [number, number] {
         const el = this.el;
 
-        return [
-            position[0] + el.offsetLeft + el.offsetWidth / 2,
-            position[1] + el.offsetTop + el.offsetHeight / 2
-        ]
+        let x = el.offsetLeft + el.offsetWidth / 2;
+        let y = el.offsetTop + el.offsetHeight / 2;
+        let searchDepth = 8;
+        let parent = el.offsetParent! as HTMLElement;
+        while (parent && parent !== this.nodeView.el && searchDepth > 0) {
+            searchDepth--;
+            x += parent.offsetLeft;
+            y += parent.offsetTop;
+            parent = parent.offsetParent as HTMLElement;
+        }
+
+        return [position[0] + x, position[1] + y];
     }
 }

--- a/src/view/socket.ts
+++ b/src/view/socket.ts
@@ -21,7 +21,7 @@ export class SocketView extends Emitter<EventsTypes> {
         this.trigger('rendersocket', { el, [type]: this.io, socket: io.socket });
     }
 
-    getPosition({ position, el: nodeViewEl }: { position: number[], el: HTMLElement }): [number, number] {
+    getPosition({ position }: { position: number[] }, nodeViewEl: HTMLElement): [number, number] {
         const { el } = this;
         const { x, y } = getOffset(el, nodeViewEl);
 

--- a/src/view/socket.ts
+++ b/src/view/socket.ts
@@ -2,7 +2,6 @@ import { Emitter } from '../core/emitter';
 import { EventsTypes } from '../events';
 import { IO } from '../io';
 import { Node } from '../node';
-import { NodeView } from './node';
 import { getOffset } from './utils';
 
 export class SocketView extends Emitter<EventsTypes> {
@@ -11,21 +10,19 @@ export class SocketView extends Emitter<EventsTypes> {
     type: string;
     io: IO;
     node: Node;
-    nodeViewEl: HTMLElement;
 
-    constructor(el: HTMLElement, type: string, io: IO, node: Node, emitter: NodeView) {
+    constructor(el: HTMLElement, type: string, io: IO, node: Node, emitter: Emitter<EventsTypes>) {
         super(emitter);
         this.el = el;
         this.type = type;
         this.io = io;
         this.node = node;
-        this.nodeViewEl = emitter.el;
 
         this.trigger('rendersocket', { el, [type]: this.io, socket: io.socket });
     }
 
-    getPosition({ position }: { position: number[] }): [number, number] {
-        const { el, nodeViewEl } = this;
+    getPosition({ position, el: nodeViewEl }: { position: number[], el: HTMLElement }): [number, number] {
+        const { el } = this;
         const { x, y } = getOffset(el, nodeViewEl);
 
         return [position[0] + x + el.offsetWidth / 2, position[1] + y + el.offsetHeight / 2];

--- a/src/view/socket.ts
+++ b/src/view/socket.ts
@@ -3,6 +3,7 @@ import { EventsTypes } from '../events';
 import { IO } from '../io';
 import { Node } from '../node';
 import { NodeView } from './node';
+import { getOffset } from './utils';
 
 export class SocketView extends Emitter<EventsTypes> {
 
@@ -10,7 +11,7 @@ export class SocketView extends Emitter<EventsTypes> {
     type: string;
     io: IO;
     node: Node;
-    nodeView: NodeView;
+    nodeViewEl: HTMLElement;
 
     constructor(el: HTMLElement, type: string, io: IO, node: Node, emitter: NodeView) {
         super(emitter);
@@ -18,25 +19,15 @@ export class SocketView extends Emitter<EventsTypes> {
         this.type = type;
         this.io = io;
         this.node = node;
-        this.nodeView = emitter
+        this.nodeViewEl = emitter.el;
 
         this.trigger('rendersocket', { el, [type]: this.io, socket: io.socket });
     }
 
     getPosition({ position }: { position: number[] }): [number, number] {
-        const el = this.el;
+        const { el, nodeViewEl } = this;
+        const { x, y } = getOffset(el, nodeViewEl);
 
-        let x = el.offsetLeft + el.offsetWidth / 2;
-        let y = el.offsetTop + el.offsetHeight / 2;
-        let searchDepth = 8;
-        let parent = el.offsetParent! as HTMLElement;
-        while (parent && parent !== this.nodeView.el && searchDepth > 0) {
-            searchDepth--;
-            x += parent.offsetLeft;
-            y += parent.offsetTop;
-            parent = parent.offsetParent as HTMLElement;
-        }
-
-        return [position[0] + x, position[1] + y];
+        return [position[0] + x + el.offsetWidth / 2, position[1] + y + el.offsetHeight / 2];
     }
 }

--- a/src/view/utils.ts
+++ b/src/view/utils.ts
@@ -5,3 +5,19 @@ export function listenWindow<K extends keyof WindowEventMap>(event: K, handler: 
         window.removeEventListener<K>(event, handler);
     }
 }
+
+
+export function getOffset(el: HTMLElement, offsetParentEl: HTMLElement, searchDepth = 8) {
+    let x = el.offsetLeft;
+    let y = el.offsetTop;
+    let parent = el.offsetParent as HTMLElement | null;
+
+    while (parent && parent !== offsetParentEl && searchDepth > 0) {
+        searchDepth--;
+        x += parent.offsetLeft;
+        y += parent.offsetTop;
+        parent = parent.offsetParent as HTMLElement | null;
+    }
+
+    return { x, y };
+}


### PR DESCRIPTION
when socket within complex layout, it's offsetParent is not NodeView.el, it have to collect offsets until NodeView.el

<img width="850" alt="image" src="https://user-images.githubusercontent.com/12824616/228802608-3728b243-861f-4c9d-a835-c984e00227e1.png">

fix before
<img width="280" alt="image" src="https://user-images.githubusercontent.com/12824616/228803132-5401ce1e-1ddf-4a51-a790-deadbeaf5249.png">

fix after
<img width="260" alt="image" src="https://user-images.githubusercontent.com/12824616/228803225-9cda587f-dfa0-40f8-9e1d-5eb456bb6b1d.png">
