### PR TITLE
Enforce String Key Types for Connection Class Properties.

### DIFF
--- a/src/presets/classic.ts
+++ b/src/presets/classic.ts
@@ -243,6 +243,8 @@ export class Node<
   }
 }
 
+type StringKeyof<T> = Extract<keyof T, string>;
+
 /**
  * The connection class
  * @priority 9
@@ -273,9 +275,9 @@ export class Connection<
    */
   constructor(
     source: Source,
-    public sourceOutput: keyof Source['outputs'],
+    public sourceOutput: StringKeyof<Source['outputs']>,
     target: Target,
-    public targetInput: keyof Target['inputs']
+    public targetInput: StringKeyof<Target['inputs']>
   ) {
     if (!source.outputs[sourceOutput as string]) {
       throw new Error(`source node doesn't have output with a key ${String(sourceOutput)}`)


### PR DESCRIPTION
Issue:
The current type definitions for the `sourceOutput` and `targetInput` properties in the `Connection` class are inferred as `keyof Source['outputs']` and `keyof Target['inputs']` respectively. In TypeScript, the `keyof` operator resolves to a union of `string | number | symbol` as object keys in JavaScript can be of any of these types. This leads to a type incompatibility issue when these properties are expected to be of type `string` in certain usage scenarios, as seen in the attached error screenshot

<img width="1244" alt="CleanShot 2566-10-22 at 17 04 34@2x" src="https://github.com/retejs/rete/assets/5212808/f3e371f8-af58-4f0b-a106-76becc76c83c">


Proposed Solution:
To enforce the `string` type for these properties and avoid the type incompatibility issue, a utility type `StringKeyof<T>` is introduced to filter out only the string keys from a type. The `Connection` class is then updated to use this utility type for the `sourceOutput` and `targetInput` properties, ensuring they are typed as `string`.

```typescript
type StringKeyof<T> = Extract<keyof T, string>;

export declare class Connection<Source extends Node, Target extends Node> implements ConnectionBase {
    sourceOutput: StringKeyof<Source['outputs']>;
    targetInput: StringKeyof<Target['inputs']>;
    // ... rest of the class ...
}
```

This adjustment aligns the type definitions with the expectation that all keys in `Source['outputs']` and `Target['inputs']` are strings, and resolves the type error encountered in the described scenario.

Attached are the error logs and a minimal reproduction case demonstrating the issue and the effectiveness of the proposed solution in resolving the type error.